### PR TITLE
Require nearest site args

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
++ Require arguments to `get_nearest_forecast_site` and `get_nearest_observation_site`.
+
 ## [0.9.5] - 2019-10-01
 
 + Remove support for Python 3.4.

--- a/datapoint/Manager.py
+++ b/datapoint/Manager.py
@@ -497,18 +497,11 @@ class Manager(object):
 
         return sites
 
-    def get_nearest_observation_site(self, latitude=None, longitude=None):
+    def get_nearest_observation_site(self, latitude, longitude):
         """
         This function returns the nearest Site to the specified
         coordinates that supports observations
         """
-        if longitude is None:
-            print('ERROR: No longitude given.')
-            return False
-
-        if latitude is None:
-            print('ERROR: No latitude given.')
-            return False
 
         nearest = False
         distance = None

--- a/datapoint/Manager.py
+++ b/datapoint/Manager.py
@@ -287,18 +287,11 @@ class Manager(object):
 
         return self.get_nearest_forecast_site(latitude, longitude)
 
-    def get_nearest_forecast_site(self, latitude=None,  longitude=None):
+    def get_nearest_forecast_site(self, latitude,  longitude):
         """
         This function returns the nearest Site object to the specified
         coordinates.
         """
-        if longitude is None:
-            print('ERROR: No latitude given.')
-            return False
-
-        if latitude is None:
-            print('ERROR: No latitude given.')
-            return False
 
         nearest = False
         distance = None


### PR DESCRIPTION
Require arguments to `get_nearest_forecast_site` and `get_nearest_observation_site`. These require arguments to get useful output anyway. Resolves #133 